### PR TITLE
fix: use correct `asset` property instead of `sourceAsset` in case of filetype without glide support

### DIFF
--- a/src/Picturesque.php
+++ b/src/Picturesque.php
@@ -236,7 +236,7 @@ class Picturesque
         ];
     
         if (! $this->isGlideSupportedFiletype()) {
-            $img['src'] = $this->sourceAsset->url();
+            $img['src'] = $this->asset->url();
         } else {
             $img['src'] = $this->makeGlideUrl(['width' => $this->smallestSrc(), 'fit' => 'crop_focal']);
         }


### PR DESCRIPTION
The `sourceAsset` property does not exist, replaced it with `asset`.