### PR TITLE
feat: add option to do image manipulation in queue

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Statamic\Facades\Site;
+use Statamic\Facades\URL;
+use VV\Picturesque\Controllers\ImageController;
+use VV\Picturesque\Picturesque;
+
+Site::all()->map(function ($site) {
+    return URL::makeRelative($site->url());
+})->unique()->each(function ($sitePrefix) {
+    Route::group(['prefix' => $sitePrefix.Picturesque::getQueueGenerationRoute()], function () {
+        Route::get('/asset/{container}/{path?}', [ImageController::class, 'generateByAsset'])->where('path', '.*');
+        Route::get('/http/{url}/{filename?}', [ImageController::class, 'generateByUrl']);
+        Route::get('{path}', [ImageController::class, 'generateByPath'])->where('path', '.*');
+    });
+});

--- a/src/Controllers/ImageController.php
+++ b/src/Controllers/ImageController.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace VV\Picturesque\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use League\Glide\Server;
+use League\Glide\Signatures\SignatureException;
+use League\Glide\Signatures\SignatureFactory;
+use Statamic\Contracts\Assets\Asset as AssetContract;
+use Statamic\Exceptions\NotFoundHttpException;
+use Statamic\Facades\Asset;
+use Statamic\Facades\AssetContainer;
+use Statamic\Facades\Config;
+use Statamic\Facades\Glide;
+use Statamic\Facades\Site;
+use Statamic\Imaging\ImageGenerator;
+use Statamic\Support\Str;
+use VV\Picturesque\Jobs\GenerateImageVariants;
+
+class ImageController extends Controller
+{
+    public function __construct(
+        private Server $server,
+        private Request $request
+    ) {}
+
+    public function generateByAsset($encoded)
+    {
+        $this->validateSignature();
+        $decoded = base64_decode($encoded);
+
+        // The string before the first slash is the container
+        [$container, $path] = explode('/', $decoded, 2);
+
+        throw_unless($container = AssetContainer::find($container), new NotFoundHttpException());
+
+        throw_unless($asset = $container->asset($path), new NotFoundHttpException);
+
+        return $this->doGenerateByAsset($asset);
+    }
+
+    private function doGenerateByAsset(AssetContract $asset)
+    {
+        $glideParameters = Glide::normalizeParameters($this->request->all());
+
+        // If the size is already generated, return it.
+        $cachedAsset = Glide::cacheStore()->get('asset::'.$asset->id().'::'.md5(json_encode($glideParameters)), null);
+        if ($cachedAsset !== null) {
+            return $this->server->getResponseFactory()->create($this->server->getCache(), $cachedAsset);
+        }
+        GenerateImageVariants::dispatch($asset, $glideParameters);
+        return $this->server->getResponseFactory()->create($this->server->getCache(), (new ImageGenerator($this->server))->generateByAsset($asset, []));
+    }
+
+    public function generateByUrl($url)
+    {
+        $this->validateSignature();
+
+        $url = base64_decode($url);
+
+        $glideParameters = Glide::normalizeParameters($this->request->all());
+
+        // If the size is already generated, return it.
+        $cachedAsset = Glide::cacheStore()->get('url::'.$url.'::'.md5(json_encode($glideParameters)), null);
+        if ($cachedAsset !== null) {
+            return $this->server->getResponseFactory()->create($this->server->getCache(), $cachedAsset);
+        }
+        GenerateImageVariants::dispatch($url, $glideParameters, 'url');
+        return $this->server->getResponseFactory()->create($this->server->getCache(), (new ImageGenerator($this->server))->generateByUrl($url, []));
+    }
+
+    public function generateByPath($path)
+    {
+        $this->validateSignature();
+
+        if (Config::get('statamic.assets.auto_crop')) {
+            if ($asset = Asset::find(Str::ensureLeft($path, '/'))) {
+                return $this->doGenerateByAsset($asset);
+            }
+        }
+
+        $glideParameters = Glide::normalizeParameters($this->request->all());
+
+        // If the size is already generated, return it.
+        $cachedAsset = Glide::cacheStore()->get('path::'.$path.'::'.md5(json_encode($glideParameters)), null);
+        if ($cachedAsset !== null) {
+            return $this->server->getResponseFactory()->create($this->server->getCache(), $cachedAsset);
+        }
+        GenerateImageVariants::dispatch($path, $glideParameters, 'path');
+        return $this->server->getResponseFactory()->create($this->server->getCache(), (new ImageGenerator($this->server))->generateByPath($path, []));
+    }
+
+    private function validateSignature()
+    {
+        // If secure images aren't enabled, don't bother validating the signature.
+        if (! Config::get('statamic.assets.image_manipulation.secure')) {
+            return;
+        }
+
+        $path = Str::after($this->request->url(), Site::current()->absoluteUrl());
+
+        try {
+            SignatureFactory::create(Config::getAppKey())->validateRequest($path, $this->request->query->all());
+        } catch (SignatureException $e) {
+            abort(400, $e->getMessage());
+        }
+    }
+}

--- a/src/Jobs/GenerateImageVariants.php
+++ b/src/Jobs/GenerateImageVariants.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace VV\Picturesque\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use League\Glide\Server;
+use Statamic\Contracts\Assets\Asset;
+use Statamic\Imaging\ImageGenerator;
+
+class GenerateImageVariants implements ShouldQueue, ShouldBeUnique
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        private Asset|string $value,
+        private array $glideParameters,
+        private string $generateBy = 'asset'
+    ) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $imageGenerator = new ImageGenerator(app(Server::class));
+        switch ($this->generateBy) {
+            case 'asset':
+                $imageGenerator->generateByAsset($this->value, $this->glideParameters);
+                break;
+            case 'url':
+                $imageGenerator->generateByUrl($this->value, $this->glideParameters);
+                break;
+            case 'path':
+                $imageGenerator->generateByPath($this->value, $this->glideParameters);
+                break;
+        }
+    }
+
+    public function uniqid(): string
+    {
+        $uniqid = $this->value;
+        if ($this->value instanceof Asset) {
+            $uniqid = $this->value->basename();
+        }
+        return md5($uniqid);
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -11,18 +11,22 @@ class ServiceProvider extends AddonServiceProvider
         \VV\Picturesque\Tags\Picture::class,
     ];
 
+    protected $routes = [
+        'web' => __DIR__.'/../routes/web.php',
+    ];
+
     public function bootAddon()
     {
         parent::boot();
-        
+
         $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'picturesque');
-        
+
         if ($this->app->runningInConsole()) {
             $this->publishes([
                 __DIR__.'/../config/config.php' => config_path('picturesque.php'),
             ], 'picturesque');
         }
-        
+
         Statamic::afterInstalled(function ($command) {
             $command->call('vendor:publish', ['--tag' => 'picturesque']);
         });


### PR DESCRIPTION
This PR adds the option to overwrite the Statamic core image manipulation with a custom route that handles the manipulation in a queue. Possible further improvements/options:

- allow to choose a `statamic.image_manipulation.presets` entry that is returned instead of the full image if the smaller sizes are not generated yet.
- allow to move the image generation to another server, so call an API in the queue instead of generating the images on the local server