### PR TITLE
Remove trailing slash for void elements

### DIFF
--- a/src/Picturesque.php
+++ b/src/Picturesque.php
@@ -155,7 +155,7 @@ class Picturesque
             $sourcetag .= " srcset='{$source['srcset']}'";
             $sourcetag .= array_key_exists('sizes', $source) ? " sizes='{$source['sizes']}'" : '';
 
-            $sourcetag .= '/>';
+            $sourcetag .= '>';
             $output .= $sourcetag;
         }
 
@@ -167,7 +167,7 @@ class Picturesque
         $output .= empty($img['loading']) ? '' : " loading='{$img['loading']}'";
         $output .= empty($img['width']) ? '' : " width='{$img['width']}'";
         $output .= empty($img['height']) ? '' : " height='{$img['height']}'";
-        $output .= "/>";
+        $output .= ">";
 
         $output .= '</picture>';
 


### PR DESCRIPTION
Prevents issues with unquoted attribute values.

https://developer.mozilla.org/en-US/docs/Glossary/Void_element

![image](https://github.com/visuellverstehen/statamic-picturesque/assets/44929138/e9ef42ee-2c7e-4a35-af82-f3979100a0f3)
