### PR TITLE
Provide integers for height and width attribute in image tag

### DIFF
--- a/src/Picturesque.php
+++ b/src/Picturesque.php
@@ -330,12 +330,12 @@ class Picturesque
 
         // width
         if ($w = $this->asset->width()) {
-            $img['width'] = $w;
+            $img['width'] = (int) round($w);
         }
 
         // height
         if ($h = $this->asset->height()) {
-            $img['height'] = $h;
+            $img['height'] = (int) round($h);
         }
 
         return $img;


### PR DESCRIPTION
HTML validation fails because the picture tag delivers float values in the img-tag.

![Bildschirmfoto 2024-02-05 um 16 15 16](https://github.com/visuellverstehen/statamic-picturesque/assets/44929138/c8de0794-b986-45bf-b030-1f53d46483ac)
