### PR TITLE
feat: V6 support and tooling

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+name: dependabot-auto-merge
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2.2.0
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Auto-merge Dependabot PRs for semver-minor updates
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-minor'}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Auto-merge Dependabot PRs for semver-patch updates
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -1,0 +1,31 @@
+name: Fix Code Style
+
+on: [push]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [8.3]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: json, dom, curl, libxml, mbstring
+          coverage: none
+
+      - name: Install Pint
+        run: composer global require laravel/pint
+
+      - name: Run Pint
+        run: pint
+
+      - name: Commit linted files
+        uses: stefanzweifel/git-auto-commit-action@v6

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,40 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main, testing ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-version: [8.3]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          tools: composer:v2
+          coverage: xdebug
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: composer-${{ matrix.php-version }}-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            composer-${{ matrix.php-version }}-
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Run Pest tests
+        run: ./vendor/bin/pest --ci --parallel

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         php-version: [8.2, 8.3, 8.4]
-        statamic-version: ['^5.0', '^6.0']
+        statamic-version: ['^5.0', '^6.0-alpha']
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,8 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [8.0, 8.1, 8.2, 8.3, 8.4]
+        php-version: [8.2, 8.3, 8.4]
+        statamic-version: ['^3.4', '^4.0', '^5.0', '^6.0']
 
     steps:
       - name: Checkout code
@@ -29,12 +30,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor
-          key: composer-${{ matrix.php-version }}-${{ hashFiles('composer.lock') }}
+          key: composer-${{ matrix.php-version }}-${{ matrix.statamic-version }}-${{ hashFiles('composer.lock') }}
           restore-keys: |
-            composer-${{ matrix.php-version }}-
+            composer-${{ matrix.php-version }}-${{ matrix.statamic-version }}-
 
       - name: Install Composer dependencies
-        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+        run: |
+          composer require statamic/cms:${{ matrix.statamic-version }} --no-interaction --prefer-dist --optimize-autoloader
 
       - name: Run Pest tests
         run: ./vendor/bin/pest --ci --parallel

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [8.2, 8.3, 8.4]
+        php-version: [8.3, 8.4]
         statamic-version: ['^5.0', '^6.0-alpha']
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [8.3]
+        php-version: [8.0, 8.1, 8.2, 8.3, 8.4]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         php-version: [8.3, 8.4]
-        statamic-version: ['^5.0', '^6.0-alpha']
+        statamic-version: ['^5.0', '^6.0']
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         php-version: [8.2, 8.3, 8.4]
-        statamic-version: ['^3.4', '^4.0', '^5.0', '^6.0']
+        statamic-version: ['^5.0', '^6.0']
 
     steps:
       - name: Checkout code

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -1,0 +1,32 @@
+name: 'Update Changelog'
+
+on:
+  release:
+    types: [released]
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Update Changelog
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          latest-version: ${{ github.event.release.name }}
+          release-notes: ${{ github.event.release.body }}
+
+      - name: Commit updated CHANGELOG
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          branch: main
+          commit_message: Update CHANGELOG
+          file_pattern: CHANGELOG.md

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "visuellverstehen/statamic-picturesque",
     "description": "A Statamic tag for building HTML-only responsive images.",
-    "keywords": [ "statamic", "addon", "responsive", "image", "picture", "glide", "v3", "v4" ],
+    "keywords": [ "statamic", "addon", "responsive", "image", "picture", "glide", "v3", "v4", "v5", "v6" ],
     "license": "MIT",
     "type": "statamic-addon",
     "autoload": {
@@ -30,7 +30,7 @@
     },
     "require": {
         "php": "^8.0",
-        "statamic/cms": "^3.4 || ^4.0 || ^5.0"
+        "statamic/cms": "^3.4 || ^4.0 || ^5.0 || ^6.0"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,7 @@
         }
     },
     "require-dev": {
-        "pestphp/pest": "^4.1"
+        "pestphp/pest": "^4.1",
+        "laravel/pint": "^1.25"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "visuellverstehen/statamic-picturesque",
     "description": "A Statamic tag for building HTML-only responsive images.",
-    "keywords": [ "statamic", "addon", "responsive", "image", "picture", "glide", "v3", "v4", "v5", "v6" ],
+    "keywords": [ "statamic", "addon", "responsive", "image", "picture", "glide", "v5", "v6" ],
     "license": "MIT",
     "type": "statamic-addon",
     "autoload": {
@@ -35,7 +35,7 @@
     },
     "require": {
         "php": "^8.2",
-        "statamic/cms": "^3.4 || ^4.0 || ^5.0 || ^6.0"
+        "statamic/cms": "^5.0 || ^6.0"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,8 @@
         }
     },
     "require": {
-        "php": "^8.0",
-        "statamic/cms": "^3.4 || ^4.0 || ^5.0 || ^6.0",
-        "orchestra/testbench": "^10.0"
+        "php": "^8.2",
+        "statamic/cms": "^3.4 || ^4.0 || ^5.0 || ^6.0"
     },
     "config": {
         "allow-plugins": {
@@ -46,6 +45,7 @@
     },
     "require-dev": {
         "pestphp/pest": "^4.1",
-        "laravel/pint": "^1.25"
+        "laravel/pint": "^1.25",
+        "orchestra/testbench": "^8.0 || ^9.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,6 @@
         "statamic/cms": "^5.0 || ^6.0"
     },
     "config": {
-        "minimum-stability": "alpha",
         "prefer-stable": true,
         "allow-plugins": {
             "pixelfear/composer-dist-plugin": true,

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         }
     },
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "statamic/cms": "^5.0 || ^6.0"
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,6 @@
     "require-dev": {
         "pestphp/pest": "^4.1",
         "laravel/pint": "^1.25",
-        "orchestra/testbench": "^8.0 || ^9.0"
+        "orchestra/testbench": "^9.0 || ^10.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,8 @@
         "statamic/cms": "^5.0 || ^6.0"
     },
     "config": {
+        "minimum-stability": "alpha",
+        "prefer-stable": true,
         "allow-plugins": {
             "pixelfear/composer-dist-plugin": true,
             "pestphp/pest-plugin": true

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,11 @@
             "VV\\Picturesque\\": "src"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
     "authors": [
         {
             "name": "visuellverstehen"
@@ -30,11 +35,16 @@
     },
     "require": {
         "php": "^8.0",
-        "statamic/cms": "^3.4 || ^4.0 || ^5.0 || ^6.0"
+        "statamic/cms": "^3.4 || ^4.0 || ^5.0 || ^6.0",
+        "orchestra/testbench": "^10.0"
     },
     "config": {
         "allow-plugins": {
-            "pixelfear/composer-dist-plugin": true
+            "pixelfear/composer-dist-plugin": true,
+            "pestphp/pest-plugin": true
         }
+    },
+    "require-dev": {
+        "pestphp/pest": "^4.1"
     }
 }

--- a/config/config.php
+++ b/config/config.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    
+
     /*
     |--------------------------------------------------------------------------
     | Breakpoints
@@ -11,7 +11,7 @@ return [
     | Note that the `default` key is mandatory.
     |
     */
-    
+
     'breakpoints' => [
         'default' => 0,
         'sm' => 640,
@@ -20,20 +20,20 @@ return [
         'xl' => 1280,
         '2xl' => 1536,
     ],
-    
+
     /*
     |--------------------------------------------------------------------------
     | Size multipliers
     |--------------------------------------------------------------------------
     |
-    | Define in which multiples of the requested image size sources should be 
+    | Define in which multiples of the requested image size sources should be
     | generated. When using the default (1, 1.5, 2) and requesting an image in
     | 300px the tag generates sizes in 300px, 450px, 600px.
     |
     */
-    
+
     'size_multipliers' => [1, 1.5, 2],
-    
+
     /*
     |--------------------------------------------------------------------------
     | Device pixel ratios
@@ -43,9 +43,9 @@ return [
     | `sizes` attribute. Use int or float values, e. g. for 2x => 2
     |
     */
-    
+
     'dpr' => [1, 2],
-    
+
     /*
     |--------------------------------------------------------------------------
     | Supported filetypes
@@ -54,9 +54,9 @@ return [
     | Define the supported filetypes for image processing.
     |
     */
-    
+
     'supported_filetypes' => ['jpg', 'jpeg', 'png', 'webp'],
-    
+
     /*
     |--------------------------------------------------------------------------
     | Default filetypes
@@ -65,9 +65,9 @@ return [
     | Define the default filetypes for generating sources.
     |
     */
-    
+
     'default_filetype' => ['webp'],
-    
+
     /*
     |--------------------------------------------------------------------------
     | Default Glide fit
@@ -76,9 +76,9 @@ return [
     | Define the default fit mode for Glide image manipulation.
     |
     */
-    
+
     'default_glide_fit' => 'crop_focal',
-    
+
     /*
     |--------------------------------------------------------------------------
     | Minimum image width
@@ -87,9 +87,9 @@ return [
     | Defines the smallest width to use for image processing in px (int).
     |
     */
-    
+
     'min_width' => 300,
-    
+
     /*
     |--------------------------------------------------------------------------
     | Lazy loading default
@@ -99,19 +99,19 @@ return [
     | You can always overwrite it by setting `lazy='false'` in the tag.
     |
     */
-    
+
     'lazyloading' => true,
-    
+
     /*
     |--------------------------------------------------------------------------
     | Full stop in alt tags
     |--------------------------------------------------------------------------
     |
-    | Setting this to true ensures that the alt text always ends with a 
+    | Setting this to true ensures that the alt text always ends with a
     | full stop.
     |
     */
-    
+
     'alt_fullstop' => false,
-    
+
 ];

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,7 +11,7 @@
     </testsuites>
     <source>
         <include>
-            <directory>app</directory>
+            <directory>src</directory>
         </include>
     </source>
     <php>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,6 +5,9 @@
     colors="true"
 >
     <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
     </testsuites>
     <source>
         <include>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,9 +5,6 @@
     colors="true"
 >
     <testsuites>
-        <testsuite name="Unit">
-            <directory>tests/Unit</directory>
-        </testsuite>
     </testsuites>
     <source>
         <include>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>app</directory>
+        </include>
+    </source>
+    <php>
+        <env name="APP_ENV" value="testing" />
+        <env name="APP_MAINTENANCE_DRIVER" value="file" />
+        <env name="BCRYPT_ROUNDS" value="4" />
+        <env name="CACHE_STORE" value="array" />
+        <!-- <env name="DB_CONNECTION" value="sqlite" /> -->
+        <!-- <env name="DB_DATABASE" value=":memory:" /> -->
+        <env name="MAIL_MAILER" value="array" />
+        <env name="PULSE_ENABLED" value="false" />
+        <env name="QUEUE_CONNECTION" value="sync" />
+        <env name="SESSION_DRIVER" value="array" />
+        <env name="TELESCOPE_ENABLED" value="false" />
+    </php>
+</phpunit>

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,3 @@
+{
+    "preset": "laravel"
+}

--- a/pint.json
+++ b/pint.json
@@ -1,3 +1,41 @@
 {
-    "preset": "laravel"
+  "preset": "laravel",
+  "rules": {
+    "blank_line_between_import_groups": true,
+    "concat_space": {
+      "spacing": "one"
+    },
+    "class_attributes_separation": {
+      "elements": {
+        "method": "one"
+      }
+    },
+    "curly_braces_position": {
+      "control_structures_opening_brace": "same_line",
+      "functions_opening_brace": "next_line_unless_newline_at_signature_end",
+      "anonymous_functions_opening_brace": "same_line",
+      "classes_opening_brace": "next_line_unless_newline_at_signature_end",
+      "anonymous_classes_opening_brace": "next_line_unless_newline_at_signature_end",
+      "allow_single_line_empty_anonymous_classes": true,
+      "allow_single_line_anonymous_functions": false
+    },
+    "explicit_string_variable": true,
+    "global_namespace_import": {
+      "import_classes": true,
+      "import_constants": true,
+      "import_functions": true
+    },
+    "new_with_braces": {
+      "named_class": true,
+      "anonymous_class": true
+    },
+    "ordered_imports": {
+      "sort_algorithm": "alpha",
+      "imports_order": ["const", "class", "function"]
+    },
+    "php_unit_test_annotation": {
+      "style": "annotation"
+    },
+    "simple_to_complex_string_variable": true
+  }
 }

--- a/src/Picturesque.php
+++ b/src/Picturesque.php
@@ -13,14 +13,23 @@ use Stringy\StaticStringy as Stringy;
 class Picturesque
 {
     private $asset;
+
     private $breakpoints;
+
     private $data;
+
     private $filetypes;
+
     private $glide;
+
     private $glideParams;
+
     private $glideSource;
+
     private $supportedFiletype;
+
     private $options;
+
     private $orientation;
 
     public function __construct(Asset|string $asset, ?Context $tagContext = null)
@@ -28,7 +37,7 @@ class Picturesque
         $this->asset = $asset;
 
         if (! $this->asset instanceof Asset && ! $this->asset = AssetFacade::find($asset)) {
-            throw new PicturesqueException('Invalid asset source: ' . (string) $asset);
+            throw new PicturesqueException('Invalid asset source: '.(string) $asset);
         }
 
         $this->breakpoints = collect();
@@ -49,7 +58,7 @@ class Picturesque
 
         $this->setupGlide($tagContext);
     }
-    
+
     public function alt(string $text): self
     {
         $this->options->put('alt', $text);
@@ -134,13 +143,13 @@ class Picturesque
             // non-breakpoint based image with `size` attribute
             if ($size = (string) $this->breakpoints->get('default')) {
                 foreach ($this->filetypes() as $filetype) {
-                    $this->data['sources']['default/' . $filetype] = $this->makeSource($this->parseParam($size), $filetype);
+                    $this->data['sources']['default/'.$filetype] = $this->makeSource($this->parseParam($size), $filetype);
                 }
             }
         }
 
         $this->data['img'] = $this->makeImg();
-        
+
         if (! empty($this->options['wrapperClass'])) {
             $this->data['wrapperClass'] = $this->options['wrapperClass'];
         }
@@ -153,18 +162,18 @@ class Picturesque
         // Filter out width/height parameters
         $restrictedParams = ['width', 'w', 'height', 'h'];
         $filteredParams = [];
-        
+
         foreach ($params as $key => $value) {
             if (! in_array($key, $restrictedParams)) {
                 $filteredParams[$key] = $value;
             }
         }
-        
+
         $this->glideParams = $filteredParams;
 
         return $this;
     }
-    
+
     public function getAsset(): Asset
     {
         return $this->asset;
@@ -204,14 +213,14 @@ class Picturesque
         $output .= empty($img['width']) ? '' : " width='{$img['width']}'";
         $output .= empty($img['height']) ? '' : " height='{$img['height']}'";
         $output .= empty($img['style']) ? '' : " style='{$img['style']}'";
-        $output .= ">";
+        $output .= '>';
 
         $output .= '</picture>';
 
         return $output;
     }
 
-    public function isGlideSupportedFiletype(): bool|null
+    public function isGlideSupportedFiletype(): ?bool
     {
         if (! $this->getAsset()) {
             return null;
@@ -278,22 +287,22 @@ class Picturesque
     private function evaluateFiletype(): string
     {
         $meta = $this->getAsset()->meta();
-        
-        if (! $meta || 
-            ! array_key_exists('mime_type', $meta) || 
-            ! is_string($meta['mime_type']) || 
+
+        if (! $meta ||
+            ! array_key_exists('mime_type', $meta) ||
+            ! is_string($meta['mime_type']) ||
             ! str_contains($meta['mime_type'], '/')
         ) {
             return null;
         }
-        
+
         $filetype = strtolower(explode('/', $meta['mime_type'])[1]);
 
         $this->supportedFiletype = in_array(
-            $filetype, 
+            $filetype,
             config('picturesque.supported_filetypes')
         );
-        
+
         return $filetype;
     }
 
@@ -368,12 +377,12 @@ class Picturesque
                 $this->glideParams,
                 ['width' => $this->smallestSrc()]
             );
-            
+
             // Only set default fit if not provided in custom params
             if (! array_key_exists('fit', $this->glideParams)) {
                 $params['fit'] = config('picturesque.default_glide_fit');
             }
-            
+
             $img['src'] = $this->makeGlideUrl($params);
         }
 
@@ -399,7 +408,7 @@ class Picturesque
             // Use processed dimensions from default breakpoint
             $defaultConfig = $this->breakpoints->get('default');
             $parsed = $this->parseParam($defaultConfig);
-            
+
             if (! empty($parsed['srcset'])) {
                 $img['width'] = (int) round($parsed['srcset']['width']);
                 $img['height'] = (int) round($parsed['srcset']['height']);
@@ -408,12 +417,12 @@ class Picturesque
             // Calculate dimensions based on smallestSrc width to match actual processed image
             $originalWidth = $this->getAsset()->width();
             $originalHeight = $this->getAsset()->height();
-            
+
             if ($originalWidth && $originalHeight) {
                 $processedWidth = $this->smallestSrc();
                 $aspectRatio = $originalHeight / $originalWidth;
                 $processedHeight = $processedWidth * $aspectRatio;
-                
+
                 $img['width'] = $processedWidth;
                 $img['height'] = (int) round($processedHeight);
             }
@@ -432,13 +441,13 @@ class Picturesque
 
         // type
         if (! in_array($format, config('picturesque.supported_filetypes'))) {
-            throw new PicturesqueException('Cannot create source for this filetype: ' . $format);
+            throw new PicturesqueException('Cannot create source for this filetype: '.$format);
         }
         $source['type'] = "image/{$format}";
 
         // media
         if ($breakpoint && array_key_exists($breakpoint, config('picturesque.breakpoints'))) {
-            $source['media'] = "(min-width: ".config('picturesque.breakpoints')[$breakpoint]."px)";
+            $source['media'] = '(min-width: '.config('picturesque.breakpoints')[$breakpoint].'px)';
         }
 
         // srcset
@@ -461,7 +470,7 @@ class Picturesque
     private function makeSourcesForBreakpoints(): array
     {
         return collect($this->filetypes())
-            ->map(function($filetype) {
+            ->map(function ($filetype) {
                 return collect(config('picturesque.breakpoints'))
                     ->sortDesc()
                     ->mapWithKeys(function ($px, $breakpoint) use ($filetype) {
@@ -497,43 +506,43 @@ class Picturesque
         if (! array_key_exists('fit', $glideOptions)) {
             $glideOptions['fit'] = config('picturesque.default_glide_fit');
         }
-        
+
         $sources = [];
         $source = $sourceData['srcset'];
 
         // with sizes
         if ($sourceData['sizes']) {
             $sources = collect(config('picturesque.size_multipliers'))
-            ->map(function ($multiplier) use ($source) {
-                return [
-                    'width' => ((float) $source['width']) * $multiplier,
-                    'height' => ((float) $source['height']) * $multiplier,
-                ];
-            })
-            ->unique()
-            ->transform(function ($sizes) use ($glideOptions) {
-                $options = array_merge($glideOptions, $sizes);
-                
-                return "{$this->makeGlideUrl($options)} {$sizes['width']}w";
-            })
-            ->toArray();
+                ->map(function ($multiplier) use ($source) {
+                    return [
+                        'width' => ((float) $source['width']) * $multiplier,
+                        'height' => ((float) $source['height']) * $multiplier,
+                    ];
+                })
+                ->unique()
+                ->transform(function ($sizes) use ($glideOptions) {
+                    $options = array_merge($glideOptions, $sizes);
+
+                    return "{$this->makeGlideUrl($options)} {$sizes['width']}w";
+                })
+                ->toArray();
         }
         // with dpr
         else {
             $sources = collect(config('picturesque.dpr'))
-            ->mapWithKeys(function ($dpr) use ($source) {
-                return [$dpr => [
-                    'width' => ((float) $source['width']) * $dpr,
-                    'height' => ((float) $source['height']) * $dpr,
-                ]];
-            })
-            ->unique()
-            ->transform(function ($sizes, $dpr) use ($glideOptions) {
-                $options = array_merge($glideOptions, $sizes);
-                
-                return "{$this->makeGlideUrl($options)} {$dpr}x";
-            })
-            ->toArray();
+                ->mapWithKeys(function ($dpr) use ($source) {
+                    return [$dpr => [
+                        'width' => ((float) $source['width']) * $dpr,
+                        'height' => ((float) $source['height']) * $dpr,
+                    ]];
+                })
+                ->unique()
+                ->transform(function ($sizes, $dpr) use ($glideOptions) {
+                    $options = array_merge($glideOptions, $sizes);
+
+                    return "{$this->makeGlideUrl($options)} {$dpr}x";
+                })
+                ->toArray();
         }
 
         return implode(',', $sources);
@@ -577,18 +586,18 @@ class Picturesque
     private function parseSizeData(string $sizeData, float|string $ratio = 'auto'): array
     {
         $size = trim($sizeData);
-        
+
         if (strpos($size, 'x')) {
             $size = explode('x', $size);
-        
+
             return [
                 'width' => $this->orientation === 'landscape' ? trim($size[0]) : trim($size[1]),
                 'height' => $this->orientation === 'portrait' ? trim($size[0]) : trim($size[1]),
             ];
         }
-        
+
         $calculatedValueOrRatio = is_float($ratio) ? ((float) $size) * $ratio : $ratio;
-        
+
         return [
             'width' => $this->orientation === 'landscape' ? $size : $calculatedValueOrRatio,
             'height' => $this->orientation === 'portrait' ? $size : $calculatedValueOrRatio,
@@ -605,10 +614,10 @@ class Picturesque
         $this->evaluateFiletype();
 
         if (! $context) {
-            $context = new Context();
+            $context = new Context;
         }
 
-        $this->glide = new Glide();
+        $this->glide = new Glide;
         $this->glide->method = 'index';
         $this->glide->tag = 'glide:index';
         $this->glide->isPair = false;
@@ -623,5 +632,4 @@ class Picturesque
     {
         return config('picturesque.min_width');
     }
-
 }

--- a/src/Picturesque.php
+++ b/src/Picturesque.php
@@ -37,7 +37,7 @@ class Picturesque
         $this->asset = $asset;
 
         if (! $this->asset instanceof Asset && ! $this->asset = AssetFacade::find($asset)) {
-            throw new PicturesqueException('Invalid asset source: '.(string) $asset);
+            throw new PicturesqueException('Invalid asset source: ' . (string) $asset);
         }
 
         $this->breakpoints = collect();
@@ -143,7 +143,7 @@ class Picturesque
             // non-breakpoint based image with `size` attribute
             if ($size = (string) $this->breakpoints->get('default')) {
                 foreach ($this->filetypes() as $filetype) {
-                    $this->data['sources']['default/'.$filetype] = $this->makeSource($this->parseParam($size), $filetype);
+                    $this->data['sources']['default/' . $filetype] = $this->makeSource($this->parseParam($size), $filetype);
                 }
             }
         }
@@ -441,13 +441,13 @@ class Picturesque
 
         // type
         if (! in_array($format, config('picturesque.supported_filetypes'))) {
-            throw new PicturesqueException('Cannot create source for this filetype: '.$format);
+            throw new PicturesqueException('Cannot create source for this filetype: ' . $format);
         }
         $source['type'] = "image/{$format}";
 
         // media
         if ($breakpoint && array_key_exists($breakpoint, config('picturesque.breakpoints'))) {
-            $source['media'] = '(min-width: '.config('picturesque.breakpoints')[$breakpoint].'px)';
+            $source['media'] = '(min-width: ' . config('picturesque.breakpoints')[$breakpoint] . 'px)';
         }
 
         // srcset
@@ -614,10 +614,10 @@ class Picturesque
         $this->evaluateFiletype();
 
         if (! $context) {
-            $context = new Context;
+            $context = new Context();
         }
 
-        $this->glide = new Glide;
+        $this->glide = new Glide();
         $this->glide->method = 'index';
         $this->glide->tag = 'glide:index';
         $this->glide->isPair = false;

--- a/src/Picturesque.php
+++ b/src/Picturesque.php
@@ -595,9 +595,10 @@ class Picturesque
                 'height' => $this->orientation === 'portrait' ? trim($size[0]) : trim($size[1]),
             ];
         }
-        
+
+        $ratio = $ratio ?? (1 / $this->getAsset()->ratio());
         $calculatedValue = ((float) $size) * $ratio;
-        
+
         return [
             'width' => $this->orientation === 'landscape' ? $size : $calculatedValue,
             'height' => $this->orientation === 'portrait' ? $size : $calculatedValue,

--- a/src/PicturesqueException.php
+++ b/src/PicturesqueException.php
@@ -4,6 +4,4 @@ namespace VV\Picturesque;
 
 use Exception;
 
-class PicturesqueException extends Exception
-{
-}
+class PicturesqueException extends Exception {}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -15,11 +15,11 @@ class ServiceProvider extends AddonServiceProvider
     {
         parent::boot();
 
-        $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'picturesque');
+        $this->mergeConfigFrom(__DIR__ . '/../config/config.php', 'picturesque');
 
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__.'/../config/config.php' => config_path('picturesque.php'),
+                __DIR__ . '/../config/config.php' => config_path('picturesque.php'),
             ], 'picturesque');
         }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -14,15 +14,15 @@ class ServiceProvider extends AddonServiceProvider
     public function bootAddon()
     {
         parent::boot();
-        
+
         $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'picturesque');
-        
+
         if ($this->app->runningInConsole()) {
             $this->publishes([
                 __DIR__.'/../config/config.php' => config_path('picturesque.php'),
             ], 'picturesque');
         }
-        
+
         Statamic::afterInstalled(function ($command) {
             $command->call('vendor:publish', ['--tag' => 'picturesque']);
         });

--- a/src/Tags/Picture.php
+++ b/src/Tags/Picture.php
@@ -62,7 +62,7 @@ class Picture extends Tags
 
         return $this->output($asset);
     }
-    
+
     protected function handleAltText(Picturesque &$picture)
     {
         // if no param is set, the asset will be checked for an alt text
@@ -70,7 +70,7 @@ class Picture extends Tags
             $picture->alt($alt);
         }
     }
-    
+
     protected function handleCssClasses(Picturesque &$picture)
     {
         if ($class = $this->params->get('class')) {
@@ -91,13 +91,12 @@ class Picture extends Tags
         if ($this->params->has('lazy')) {
             if ($this->params->get('lazy') == false) {
                 $picture->lazy(false);
-            }
-            else {
+            } else {
                 $picture->lazy(true);
             }
         }
     }
-    
+
     protected function handleWrapperCssClasses(Picturesque &$picture)
     {
         if ($wrapperClass = $this->params->get('wrapperClass')) {
@@ -134,7 +133,7 @@ class Picture extends Tags
 
             if (str_contains($filetypes, ',')) {
                 $filetypes = explode(',', $filetypes);
-            } else if (str_contains($filetypes, '|')) {
+            } elseif (str_contains($filetypes, '|')) {
                 $filetypes = explode('|', $filetypes);
             }
 
@@ -173,7 +172,7 @@ class Picture extends Tags
 
         $picture->generate();
 
-        if ($this->mode == 'json' || $this->mode == 'array' ) {
+        if ($this->mode == 'json' || $this->mode == 'array') {
             return $picture->json();
         }
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -45,34 +45,3 @@ expect()->extend('toBeOne', function () {
 | Custom Expectations
 |--------------------------------------------------------------------------
 */
-
-expect()->extend('toBeTrackedFor', function ($asset, $expectedCount = 1) {
-    // $this->value is the entry
-    $entry = $this->value;
-    $assetPath = $asset->path();
-    $assetContainer = 'assets';
-    $entryId = $entry->id();
-
-    // Check if a reference exists
-    $exists = \Illuminate\Support\Facades\DB::table('asset_atlas')
-        ->where('asset_path', $assetPath)
-        ->where('asset_container', $assetContainer)
-        ->where('item_id', $entryId)
-        ->exists();
-
-    expect($exists)->toBeTrue(
-        "Expected asset reference for '{$assetPath}' in entry '{$entryId}' to exist in asset_atlas table, but it was not found."
-    );
-
-    // Verify the expected count
-    $actualCount = \Illuminate\Support\Facades\DB::table('asset_atlas')
-        ->where('asset_path', $assetPath)
-        ->where('item_id', $entryId)
-        ->count();
-
-    expect($actualCount)->toBe($expectedCount,
-        "Expected {$expectedCount} reference(s) for asset '{$assetPath}' in entry '{$entryId}', but found {$actualCount}."
-    );
-
-    return $this; // Enable chaining
-});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+| The closure you provide to your test functions is always bound to a specific PHPUnit test
+| case class. By default, that class is "PHPUnit\Framework\TestCase". Of course, you may
+| need to change it using the "pest()" function to bind a different classes or traits.
+|
+*/
+
+pest()->extend(Tests\TestCase::class)
+    ->in('Unit');
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+| When you're writing tests, you often need to check that values meet certain conditions. The
+| "expect()" function gives you access to a set of "expectations" methods that you can use
+| to assert different things. Of course, you may extend the Expectation API at any time.
+|
+*/
+
+expect()->extend('toBeOne', function () {
+    return $this->toBe(1);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+| While Pest is very powerful out-of-the-box, you may have some testing code specific to your
+| project that you don't want to repeat in every file. Here you can also expose helpers as
+| global functions to help you to reduce the number of lines of code in your test files.
+|
+*/
+
+/*
+|--------------------------------------------------------------------------
+| Custom Expectations
+|--------------------------------------------------------------------------
+*/
+
+expect()->extend('toBeTrackedFor', function ($asset, $expectedCount = 1) {
+    // $this->value is the entry
+    $entry = $this->value;
+    $assetPath = $asset->path();
+    $assetContainer = 'assets';
+    $entryId = $entry->id();
+
+    // Check if a reference exists
+    $exists = \Illuminate\Support\Facades\DB::table('asset_atlas')
+        ->where('asset_path', $assetPath)
+        ->where('asset_container', $assetContainer)
+        ->where('item_id', $entryId)
+        ->exists();
+
+    expect($exists)->toBeTrue(
+        "Expected asset reference for '{$assetPath}' in entry '{$entryId}' to exist in asset_atlas table, but it was not found."
+    );
+
+    // Verify the expected count
+    $actualCount = \Illuminate\Support\Facades\DB::table('asset_atlas')
+        ->where('asset_path', $assetPath)
+        ->where('item_id', $entryId)
+        ->count();
+
+    expect($actualCount)->toBe($expectedCount,
+        "Expected {$expectedCount} reference(s) for asset '{$assetPath}' in entry '{$entryId}', but found {$actualCount}."
+    );
+
+    return $this; // Enable chaining
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,7 +14,15 @@ abstract class TestCase extends AddonTestCase
 
     protected function setUp(): void
     {
+        // Statamic's AddonTestCase calls addToAssertionCount() with negative
+        // values to offset Mockery expectations. PHPUnit 11+ asserts $count >= 0,
+        // causing problems, so we temporarily disable PHP assertions.
+        $previousAssertions = ini_get('zend.assertions');
+        ini_set('zend.assertions', 0);
+
         parent::setUp();
+
+        ini_set('zend.assertions', $previousAssertions);
     }
 
     protected function resolveApplicationConfiguration($app)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Statamic\Testing\AddonTestCase;
+use VV\Picturesque\ServiceProvider;
+
+abstract class TestCase extends AddonTestCase
+{
+    use RefreshDatabase;
+
+    protected string $addonServiceProvider = ServiceProvider::class;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function resolveApplicationConfiguration($app)
+    {
+        parent::resolveApplicationConfiguration($app);
+
+        $app['config']->set('statamic.editions.pro', true);
+    }
+}

--- a/tests/Unit/ExampleUnitTest.php
+++ b/tests/Unit/ExampleUnitTest.php
@@ -1,0 +1,5 @@
+<?php
+
+test('example', function () {
+    expect(true)->toBeTrue();
+});

--- a/tests/Unit/ExampleUnitTest.php
+++ b/tests/Unit/ExampleUnitTest.php
@@ -1,5 +1,0 @@
-<?php
-
-test('example', function () {
-    expect(true)->toBeTrue();
-});


### PR DESCRIPTION
## Notes

I'm a bit torn here. If we want to use Pest 4, we need to use php 8.3 which might be a bit much of a jump from the previously supporte v8.0. We can of course just not bump it in the composer.json and just don't test against it.