### PR TITLE
Bring back comma-separated sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,10 @@ The tag supports ratios as `1.5:1` or `1.5/1`, so use whichever way you prefer.
 
 #### Multiple source widths
 
-Instead of relying on the configured size multipliers you can explicitly define multiple widths for a single source by separating them with commas:  
-`{{ picture:img size="300,600,900 | auto | 100vw" }}`  
+Instead of relying solely on the configured size multipliers you can explicitly define multiple widths for a single source by separating them with commas:  
+`{{ picture:img size="300,600,900 | 1.5:1 | 100vw" }}`  
 
-Each width becomes its own srcset candidate (multiplied by the configured `size_multipliers`, with duplicate entries removed). You can also mix single widths with explicit dimensions:  
-`{{ picture:img size="300,600x200 | auto | 100vw" }}`  
-
-Results in:
+Each width becomes its own srcset candidate (still multiplied by the configured `size_multipliers`, with duplicate entries removed). Results in:
 
 ```HTML
 <picture>
@@ -155,7 +152,8 @@ Results in:
 
 Please note:
 - Comma-separated widths **require a `sizes` value** (the third pipe segment). Without it the browser would receive multiple sources with identical DPR descriptors, so Picturesque throws an error instead.
-- The first value is used for the `width`/`height` attributes of the generated elements.
+- All candidates of a source share **one aspect ratio** (the second pipe segment, or `auto`). A srcset must contain the same image at different resolutions, so explicit `WIDTHxHEIGHT` values are not allowed in comma-separated lists. Use the ratio segment instead: `300,600 | 3:1 | 100vw` rather than `300x100,600x200`.
+- The first value is used for the `width` and `height` attributes of the generated elements.
 - This works for breakpoint attributes as well: `{{ picture:img default="300,600 | auto | 100vw" md="600,1200 | auto | 80vw" }}`
 
 #### Format/filetypes
@@ -293,4 +291,3 @@ The addon provides several configuration options through it's `config/picturesqu
 
 ## License
 The MIT license (MIT). Please take a look at the [license file](LICENSE.md) for more information.
-

--- a/README.md
+++ b/README.md
@@ -128,6 +128,36 @@ If you want to use `width x height` as well as the `sizes` attribute, simply use
 
 The tag supports ratios as `1.5:1` or `1.5/1`, so use whichever way you prefer.
 
+#### Multiple source widths
+
+Instead of relying on the configured size multipliers you can explicitly define multiple widths for a single source by separating them with commas:  
+`{{ picture:img size="300,600,900 | auto | 100vw" }}`  
+
+Each width becomes its own srcset candidate (multiplied by the configured `size_multipliers`, with duplicate entries removed). You can also mix single widths with explicit dimensions:  
+`{{ picture:img size="300,600x200 | auto | 100vw" }}`  
+
+Results in:
+
+```HTML
+<picture>
+    <source type="image/webp" srcset="
+        [img-url]?fm=webp&amp;fit=crop&amp;w=300&amp;h=200&amp;s=[…] 300w,
+        [img-url]?fm=webp&amp;fit=crop&amp;w=450&amp;h=300&amp;s=[…] 450w,
+        [img-url]?fm=webp&amp;fit=crop&amp;w=600&amp;h=400&amp;s=[…] 600w,
+        [img-url]?fm=webp&amp;fit=crop&amp;w=900&amp;h=600&amp;s=[…] 900w,
+        [img-url]?fm=webp&amp;fit=crop&amp;w=1200&amp;h=800&amp;s=[…] 1200w,
+        [img-url]?fm=webp&amp;fit=crop&amp;w=1350&amp;h=900&amp;s=[…] 1350w,
+        [img-url]?fm=webp&amp;fit=crop&amp;w=1800&amp;h=1200&amp;s=[…] 1800w
+    " sizes="100vw" width="300" height="200">
+    <img src="[img-url]?w=300&amp;fit=crop&amp;s=[…]" loading="lazy" width="300" height="200">
+</picture>
+```
+
+Please note:
+- Comma-separated widths **require a `sizes` value** (the third pipe segment). Without it the browser would receive multiple sources with identical DPR descriptors, so Picturesque throws an error instead.
+- The first value is used for the `width`/`height` attributes of the generated elements.
+- This works for breakpoint attributes as well: `{{ picture:img default="300,600 | auto | 100vw" md="600,1200 | auto | 80vw" }}`
+
 #### Format/filetypes
 
 You can optionally add one or more filetypes for image conversion:  

--- a/src/Picturesque.php
+++ b/src/Picturesque.php
@@ -603,7 +603,23 @@ class Picturesque
      */
     public function parseSizeData(string $sizeData, ?float $ratio = null): array
     {
-        return collect(explode(',', $sizeData))
+        $sizes = explode(',', $sizeData);
+
+        // All candidates of a srcset must share the same aspect ratio,
+        // so explicit WIDTHxHEIGHT values are not allowed in comma-separated lists.
+        if (count($sizes) > 1) {
+            foreach ($sizes as $size) {
+                if (strpos(trim($size), 'x')) {
+                    throw new PicturesqueException(
+                        "Invalid size value \"{$sizeData}\": explicit WIDTHxHEIGHT is not supported in comma-separated lists "
+                        . 'because all srcset candidates must share the same aspect ratio. '
+                        . 'Use the ratio segment instead, e.g. "300,600 | 3:1 | 100vw".'
+                    );
+                }
+            }
+        }
+
+        return collect($sizes)
             ->map(fn ($size) => $this->parseSingleSize($size, $ratio))
             ->toArray();
     }

--- a/src/Picturesque.php
+++ b/src/Picturesque.php
@@ -409,9 +409,9 @@ class Picturesque
             $defaultConfig = $this->breakpoints->get('default');
             $parsed = $this->parseParam($defaultConfig);
 
-            if (! empty($parsed['srcset'])) {
-                $img['width'] = (int) round($parsed['srcset']['width']);
-                $img['height'] = (int) round($parsed['srcset']['height']);
+            if (isset($parsed['srcset'][0])) {
+                $img['width'] = (int) round($parsed['srcset'][0]['width']);
+                $img['height'] = (int) round($parsed['srcset'][0]['height']);
             }
         } else {
             // Calculate dimensions based on smallestSrc width to match actual processed image
@@ -459,9 +459,10 @@ class Picturesque
         }
 
         // width and height attributes
-        if (! empty($sourceData['srcset'])) {
-            $source['width'] = (int) round($sourceData['srcset']['width']);
-            $source['height'] = (int) round($sourceData['srcset']['height']);
+        // Use the primary (first) source for the attributes
+        if (isset($sourceData['srcset'][0])) {
+            $source['width'] = (int) round($sourceData['srcset'][0]['width']);
+            $source['height'] = (int) round($sourceData['srcset'][0]['height']);
         }
 
         return $source;
@@ -508,44 +509,56 @@ class Picturesque
         }
 
         $sources = [];
-        $source = $sourceData['srcset'];
 
-        // with sizes
-        if ($sourceData['sizes']) {
-            $sources = collect(config('picturesque.size_multipliers'))
-                ->map(function ($multiplier) use ($source) {
-                    return [
-                        'width' => ((float) $source['width']) * $multiplier,
-                        'height' => ((float) $source['height']) * $multiplier,
-                    ];
-                })
-                ->unique()
-                ->transform(function ($sizes) use ($glideOptions) {
-                    $options = array_merge($glideOptions, $sizes);
+        foreach ($sourceData['srcset'] as $source) {
+            // with sizes
+            if ($sourceData['sizes']) {
+                $sources = array_merge(
+                    $sources,
+                    collect(config('picturesque.size_multipliers'))
+                        ->map(function ($multiplier) use ($source) {
+                            return [
+                                'width' => ((float) $source['width']) * $multiplier,
+                                'height' => ((float) $source['height']) * $multiplier,
+                            ];
+                        })
+                        ->unique()
+                        ->transform(function ($sizes) use ($glideOptions) {
+                            $options = array_merge($glideOptions, $sizes);
 
-                    return "{$this->makeGlideUrl($options)} {$sizes['width']}w";
-                })
-                ->toArray();
+                            return "{$this->makeGlideUrl($options)} {$sizes['width']}w";
+                        })
+                        ->toArray()
+                );
+            }
+            // with dpr
+            else {
+                $sources = array_merge(
+                    $sources,
+                    collect(config('picturesque.dpr'))
+                        ->mapWithKeys(function ($dpr) use ($source) {
+                            return [$dpr => [
+                                'width' => ((float) $source['width']) * $dpr,
+                                'height' => ((float) $source['height']) * $dpr,
+                            ]];
+                        })
+                        ->unique()
+                        ->transform(function ($sizes, $dpr) use ($glideOptions) {
+                            $options = array_merge($glideOptions, $sizes);
+
+                            return "{$this->makeGlideUrl($options)} {$dpr}x";
+                        })
+                        ->values()
+                        ->toArray()
+                );
+            }
         }
-        // with dpr
-        else {
-            $sources = collect(config('picturesque.dpr'))
-                ->mapWithKeys(function ($dpr) use ($source) {
-                    return [$dpr => [
-                        'width' => ((float) $source['width']) * $dpr,
-                        'height' => ((float) $source['height']) * $dpr,
-                    ]];
-                })
-                ->unique()
-                ->transform(function ($sizes, $dpr) use ($glideOptions) {
-                    $options = array_merge($glideOptions, $sizes);
 
-                    return "{$this->makeGlideUrl($options)} {$dpr}x";
-                })
-                ->toArray();
-        }
-
-        return implode(',', $sources);
+        // remove duplicate descriptors
+        // (e. g. "300,600" with multipliers 1 and 2 both produce a 600w source)
+        return collect($sources)
+            ->unique(fn ($entry) => substr($entry, strrpos($entry, ' ') + 1))
+            ->implode(',');
     }
 
     /**
@@ -560,30 +573,42 @@ class Picturesque
 
         if (! strpos($data, '|')) {
             $result['srcset'] = $this->parseSizeData(trim($data));
+        } else {
+            $parts = explode('|', $data);
 
-            return $result;
+            $result['srcset'] = $this->parseSizeData(
+                trim($parts[0]),
+                $this->calcRatio(trim($parts[1]))
+            );
+
+            if (count($parts) > 2) {
+                $result['sizes'] = trim($parts[2]);
+            }
         }
 
-        $data = explode('|', $data);
-
-        $result['srcset'] = $this->parseSizeData(
-            trim($data[0]),
-            $this->calcRatio(trim($data[1]))
-        );
-
-        if (count($data) > 2) {
-            $result['sizes'] = trim($data[2]);
+        if (count($result['srcset']) > 1 && empty($result['sizes'])) {
+            throw new PicturesqueException(
+                "Invalid size value \"{$data}\": multiple comma-separated widths require a sizes value, "
+                . 'e.g. "300,600 | auto | 100vw".'
+            );
         }
 
         return $result;
     }
 
     /**
-     * Converts a string with srcset information into a structured array.
-     * e.g. "600x200" -> ['width' => 600, 'height' => 200]
+     * Converts a string with srcset information into a structured array of sources.
+     * e.g. "300,600x200" -> [['width' => 300, ...], ['width' => 600, 'height' => 200]]
      * Supports a $ratio option to calc height (if no explicit height supplied).
      */
     public function parseSizeData(string $sizeData, ?float $ratio = null): array
+    {
+        return collect(explode(',', $sizeData))
+            ->map(fn ($size) => $this->parseSingleSize($size, $ratio))
+            ->toArray();
+    }
+
+    private function parseSingleSize(string $sizeData, ?float $ratio = null): array
     {
         $size = trim($sizeData);
 
@@ -621,8 +646,8 @@ class Picturesque
 
         throw new PicturesqueException(
             "Invalid size value \"{$original}\": width and height must be numeric. "
-            . 'Use a single width ("300"), explicit dimensions ("300x200") '
-            . 'or width with ratio ("300|1.5:1"). Commas are not supported in the size value.'
+            . 'Use a single width ("300"), explicit dimensions ("300x200"), '
+            . 'width with ratio ("300|1.5:1") or comma-separated widths ("300,600 | auto | 100vw").'
         );
     }
 

--- a/src/Picturesque.php
+++ b/src/Picturesque.php
@@ -598,7 +598,7 @@ class Picturesque
 
     /**
      * Converts a string with srcset information into a structured array of sources.
-     * e.g. "300,600x200" -> [['width' => 300, ...], ['width' => 600, 'height' => 200]]
+     * e.g. "300,600" with ratio 0.5 -> [['width' => 300, 'height' => 150], ['width' => 600, 'height' => 300]]
      * Supports a $ratio option to calc height (if no explicit height supplied).
      */
     public function parseSizeData(string $sizeData, ?float $ratio = null): array

--- a/tests/Feature/PicturesqueClassTest.php
+++ b/tests/Feature/PicturesqueClassTest.php
@@ -315,6 +315,54 @@ it('generates w descriptors when sizes are specified', function () {
         ->not->toContain('1x');
 });
 
+it('generates srcset entries for comma-separated widths', function () {
+    $html = $this->picturesque('landscape')
+        ->default('300,600 | 2:1 | 100vw')
+        ->generate()
+        ->html();
+
+    // Multipliers (1, 1.5, 2) per width, deduplicated by descriptor:
+    // 300 -> 300w, 450w, 600w; 600 -> 600w (duplicate), 900w, 1200w
+    expect($html)
+        ->toContain('300w')
+        ->toContain('450w')
+        ->toContain('600w')
+        ->toContain('900w')
+        ->toContain('1200w')
+        ->toContain("sizes='100vw'");
+
+    // duplicate 600w descriptor is removed
+    preg_match("/srcset='([^']+)'/", $html, $match);
+    expect(substr_count($match[1], ' 600w'))->toBe(1);
+
+    // width/height attributes use the first (primary) source
+    expect($html)
+        ->toContain("width='300'")
+        ->toContain("height='150'");
+});
+
+it('supports comma-separated widths in breakpoints', function () {
+    $html = $this->picturesque('landscape')
+        ->default('300,600 | auto | 100vw')
+        ->breakpoint('md', '600,1200 | auto | 80vw')
+        ->generate()
+        ->html();
+
+    expect($html)
+        ->toContain('(min-width: 768px)')
+        ->toContain("sizes='100vw'")
+        ->toContain("sizes='80vw'")
+        ->toContain('300w')
+        ->toContain('1200w')
+        ->toContain('2400w');
+});
+
+it('throws when comma-separated widths are used without sizes', function () {
+    $this->picturesque('landscape')
+        ->default('300,600')
+        ->generate();
+})->throws(PicturesqueException::class, 'require a sizes value');
+
 it('can chain all options fluently', function () {
     $html = $this->picturesque('landscape')
         ->default('300|1.5:1|100vw')

--- a/tests/Unit/ParseParamTest.php
+++ b/tests/Unit/ParseParamTest.php
@@ -1,32 +1,53 @@
 <?php
 
+use VV\Picturesque\PicturesqueException;
+
 it('parses a simple size string without ratio or sizes', function () {
     $result = $this->picturesque('landscape')->parseParam('600x400');
 
-    expect($result['srcset'])->toBe(['width' => '600', 'height' => '400'])
+    expect($result['srcset'])->toBe([['width' => '600', 'height' => '400']])
         ->and($result['sizes'])->toBeNull();
 });
 
 it('parses a width-only string and uses auto ratio', function () {
     $result = $this->picturesque('landscape')->parseParam('800');
 
-    expect($result['srcset']['width'])->toBe('800')
-        ->and($result['srcset']['height'])->toBeGreaterThan(0)
+    expect($result['srcset'][0]['width'])->toBe('800')
+        ->and($result['srcset'][0]['height'])->toBeGreaterThan(0)
         ->and($result['sizes'])->toBeNull();
 });
 
 it('parses width with explicit ratio', function () {
     $result = $this->picturesque('landscape')->parseParam('600|16:9');
 
-    expect($result['srcset']['width'])->toBe('600')
-        ->and($result['srcset']['height'])->toBe(337.5) // 600 * (9/16)
+    expect($result['srcset'][0]['width'])->toBe('600')
+        ->and($result['srcset'][0]['height'])->toBe(337.5) // 600 * (9/16)
         ->and($result['sizes'])->toBeNull();
 });
 
 it('parses width with ratio and sizes attribute', function () {
     $result = $this->picturesque('landscape')->parseParam('600|1:1|100vw');
 
-    expect($result['srcset']['width'])->toBe('600')
-        ->and($result['srcset']['height'])->toBe(600.0)
+    expect($result['srcset'][0]['width'])->toBe('600')
+        ->and($result['srcset'][0]['height'])->toBe(600.0)
         ->and($result['sizes'])->toBe('100vw');
 });
+
+it('parses comma-separated widths with ratio and sizes attribute', function () {
+    $result = $this->picturesque('landscape')->parseParam('300,600 | 2:1 | 100vw');
+
+    expect($result['srcset'])->toHaveCount(2)
+        ->and($result['srcset'][0]['width'])->toBe('300')
+        ->and($result['srcset'][0]['height'])->toBe(150.0)
+        ->and($result['srcset'][1]['width'])->toBe('600')
+        ->and($result['srcset'][1]['height'])->toBe(300.0)
+        ->and($result['sizes'])->toBe('100vw');
+});
+
+it('throws when comma-separated widths are used without a sizes value', function () {
+    $this->picturesque('landscape')->parseParam('300,600');
+})->throws(PicturesqueException::class, 'require a sizes value');
+
+it('throws when comma-separated widths have a ratio but no sizes value', function () {
+    $this->picturesque('landscape')->parseParam('300,600 | 2:1');
+})->throws(PicturesqueException::class, 'require a sizes value');

--- a/tests/Unit/ParseSizeDataTest.php
+++ b/tests/Unit/ParseSizeDataTest.php
@@ -76,34 +76,21 @@ it('parses comma-separated widths into multiple sources', function () {
         ->and($result[1]['height'])->toBe(300.0);
 });
 
-it('parses mixed comma-separated sizes with explicit dimensions', function () {
-    $result = $this->picturesque('landscape')->parseSizeData('300,600x200', 0.5);
-
-    expect($result)->toHaveCount(2)
-        ->and($result[0]['width'])->toBe('300')
-        ->and($result[0]['height'])->toBe(150.0)
-        ->and($result[1])->toBe([
-            'width' => '600',
-            'height' => '200',
-        ]);
-});
-
 it('parses comma-separated sizes in portrait mode', function () {
     $result = $this->picturesque('landscape')
         ->orientation('portrait')
-        ->parseSizeData('600x200,800x400');
+        ->parseSizeData('300,600', 0.5);
 
-    expect($result)->toBe([
-        [
-            'width' => '200',
-            'height' => '600',
-        ],
-        [
-            'width' => '400',
-            'height' => '800',
-        ],
-    ]);
+    expect($result)->toHaveCount(2)
+        ->and($result[0]['width'])->toBe(150.0)
+        ->and($result[0]['height'])->toBe('300')
+        ->and($result[1]['width'])->toBe(300.0)
+        ->and($result[1]['height'])->toBe('600');
 });
+
+it('throws when explicit dimensions are used in comma-separated lists', function () {
+    $this->picturesque('landscape')->parseSizeData('300,600x200', 0.5);
+})->throws(PicturesqueException::class, 'not supported in comma-separated lists');
 
 it('throws a helpful error for non-numeric width x height', function () {
     $this->picturesque('landscape')->parseSizeData('foox200');

--- a/tests/Unit/ParseSizeDataTest.php
+++ b/tests/Unit/ParseSizeDataTest.php
@@ -6,8 +6,10 @@ it('parses explicit width x height in landscape mode', function () {
     $result = $this->picturesque('landscape')->parseSizeData('600x200');
 
     expect($result)->toBe([
-        'width' => '600',
-        'height' => '200',
+        [
+            'width' => '600',
+            'height' => '200',
+        ],
     ]);
 });
 
@@ -17,16 +19,18 @@ it('parses explicit width x height in portrait mode', function () {
         ->parseSizeData('600x200');
 
     expect($result)->toBe([
-        'width' => '200',
-        'height' => '600',
+        [
+            'width' => '200',
+            'height' => '600',
+        ],
     ]);
 });
 
 it('calculates height from width and ratio in landscape mode', function () {
     $result = $this->picturesque('landscape')->parseSizeData('600', 0.5);
 
-    expect($result['width'])->toBe('600')
-        ->and($result['height'])->toBe(300.0);
+    expect($result[0]['width'])->toBe('600')
+        ->and($result[0]['height'])->toBe(300.0);
 });
 
 it('calculates width from height and ratio in portrait mode', function () {
@@ -34,38 +38,77 @@ it('calculates width from height and ratio in portrait mode', function () {
         ->orientation('portrait')
         ->parseSizeData('600', 0.5);
 
-    expect($result['width'])->toBe(300.0)
-        ->and($result['height'])->toBe('600');
+    expect($result[0]['width'])->toBe(300.0)
+        ->and($result[0]['height'])->toBe('600');
 });
 
 it('uses auto ratio from asset when no ratio is provided', function () {
     // Asset is 1600x900, auto ratio = 900/1600 = 0.5625
     $result = $this->picturesque('landscape')->parseSizeData('800');
 
-    expect($result['width'])->toBe('800')
-        ->and($result['height'])->toBe(800.0 * (900 / 1600));
+    expect($result[0]['width'])->toBe('800')
+        ->and($result[0]['height'])->toBe(800.0 * (900 / 1600));
 });
 
 it('uses auto ratio for square asset', function () {
     // Asset is 800x800, auto ratio = 1.0
     $result = $this->picturesque('square')->parseSizeData('400');
 
-    expect($result['width'])->toBe('400')
-        ->and($result['height'])->toBe(400.0);
+    expect($result[0]['width'])->toBe('400')
+        ->and($result[0]['height'])->toBe(400.0);
 });
 
 it('does not crash when ratio is null', function () {
     // Regression test for PR #28 — must not throw or produce 0
     $result = $this->picturesque('landscape')->parseSizeData('300');
 
-    expect($result['width'])->toBe('300')
-        ->and($result['height'])->toBeGreaterThan(0);
+    expect($result[0]['width'])->toBe('300')
+        ->and($result[0]['height'])->toBeGreaterThan(0);
 });
 
-it('throws a helpful error for a comma in the width attribute', function () {
-    $this->picturesque('landscape')->parseSizeData('300,600');
-})->throws(PicturesqueException::class, 'Commas are not supported');
+it('parses comma-separated widths into multiple sources', function () {
+    $result = $this->picturesque('landscape')->parseSizeData('300,600', 0.5);
+
+    expect($result)->toHaveCount(2)
+        ->and($result[0]['width'])->toBe('300')
+        ->and($result[0]['height'])->toBe(150.0)
+        ->and($result[1]['width'])->toBe('600')
+        ->and($result[1]['height'])->toBe(300.0);
+});
+
+it('parses mixed comma-separated sizes with explicit dimensions', function () {
+    $result = $this->picturesque('landscape')->parseSizeData('300,600x200', 0.5);
+
+    expect($result)->toHaveCount(2)
+        ->and($result[0]['width'])->toBe('300')
+        ->and($result[0]['height'])->toBe(150.0)
+        ->and($result[1])->toBe([
+            'width' => '600',
+            'height' => '200',
+        ]);
+});
+
+it('parses comma-separated sizes in portrait mode', function () {
+    $result = $this->picturesque('landscape')
+        ->orientation('portrait')
+        ->parseSizeData('600x200,800x400');
+
+    expect($result)->toBe([
+        [
+            'width' => '200',
+            'height' => '600',
+        ],
+        [
+            'width' => '400',
+            'height' => '800',
+        ],
+    ]);
+});
 
 it('throws a helpful error for non-numeric width x height', function () {
     $this->picturesque('landscape')->parseSizeData('foox200');
+})->throws(PicturesqueException::class, 'must be numeric');
+
+it('throws a helpful error for non-numeric comma-separated values', function () {
+    $this->picturesque('landscape')->parseSizeData('300,foo');
 })->throws(PicturesqueException::class, 'must be numeric');


### PR DESCRIPTION
This brings back comma-separated source width values, e. g. `{{ picture:img size="300,600,900 | auto | 100vw" }}`.